### PR TITLE
make span display to inline for mobile view

### DIFF
--- a/src/VocabularyFlashCard.Web/ClientApp/src/pages/List/VocTable.vue
+++ b/src/VocabularyFlashCard.Web/ClientApp/src/pages/List/VocTable.vue
@@ -62,10 +62,10 @@ export default defineComponent({
 
 				<div class="col-md-2">
 					<span class="me-1 fw-bold">
-					<span class="d-none d-sm-block">
+					<span class="d-none d-sm-inline">
 						{{ voc.word }}
 					</span>
-					<span class="fs-2 d-block d-sm-none">
+					<span class="fs-2 d-inline d-sm-none">
 						{{ voc.word }}
 					</span>
 				</span>


### PR DESCRIPTION
make the "span" display inline for mobile view, this will help the mark star show after the vocabulary.